### PR TITLE
Write scenarios xml file: fix error in case parent directory does not exist

### DIFF
--- a/nndependability/metrics/ScenarioKProjection.py
+++ b/nndependability/metrics/ScenarioKProjection.py
@@ -83,7 +83,8 @@ class Scenario_KProjection_Metric():
         newScenario = ET.tostring(top, "utf-8")
         reparsed = minidom.parseString(newScenario)
         #print(reparsed.toprettyxml(indent="  "))
-        os.makedirs(os.path.dirname(outputFile), exist_ok=True)
+        if os.path.dirname(outputFile):
+            os.makedirs(os.path.dirname(outputFile), exist_ok=True)
         secnarioFile = open(outputFile, "w")
         secnarioFile.write(reparsed.toprettyxml(indent="  "))
         secnarioFile.close()

--- a/nndependability/metrics/ScenarioKProjection.py
+++ b/nndependability/metrics/ScenarioKProjection.py
@@ -1,3 +1,4 @@
+import os
 import numpy as np 
 import scipy
 import math
@@ -82,6 +83,7 @@ class Scenario_KProjection_Metric():
         newScenario = ET.tostring(top, "utf-8")
         reparsed = minidom.parseString(newScenario)
         #print(reparsed.toprettyxml(indent="  "))
+        os.makedirs(os.path.dirname(outputFile), exist_ok=True)
         secnarioFile = open(outputFile, "w")
         secnarioFile.write(reparsed.toprettyxml(indent="  "))
         secnarioFile.close()


### PR DESCRIPTION
At least under windows, the default path `local/tmp.xml` directory does not exist and throws an error when trying to open the `tmp.xml` file.

- `os.makedirs` creates all given directories
- check beforehand if the path even contains a directory

**Requires Python > 3.2** but that seems to be given.

Thanks for putting this stuff on github:)